### PR TITLE
Clean outdated binary packages from PKGDIR

### DIFF
--- a/app-portage/genup/files/updaters.d/23-eclean-packages.sh
+++ b/app-portage/genup/files/updaters.d/23-eclean-packages.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Clean outdated binary packages from PKGDIR in Gentoo.
+set -e
+eclean --deep packages


### PR DESCRIPTION
I created simple script `23-eclean-packages.sh` which runs `eclean --deep packages` (via /etc/genup/updaters.d).
