### PR TITLE
Add script 30-prelink-update.sh to genup

### DIFF
--- a/app-portage/genup/files/updaters.d/30-prelink-update.sh
+++ b/app-portage/genup/files/updaters.d/30-prelink-update.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Prelink all the binaries given by /etc/prelink.conf.
+# Please make sure you have properly configured prelink before using this!
+# See https://wiki.gentoo.org/wiki/Prelink
+set -e
+prelink --all --conserve-memory --random


### PR DESCRIPTION
I created script for updating prelinked binaries. Command taken from: [https://wiki.gentoo.org/wiki/Prelink#Prelink_Usage](https://wiki.gentoo.org/wiki/Prelink#Prelink_Usage).

This script is not tested, but should work. I am not using prelink so I can't test it.
